### PR TITLE
Fixed path of View articles button on admin page

### DIFF
--- a/src/resources/views/components/admin/cards.blade.php
+++ b/src/resources/views/components/admin/cards.blade.php
@@ -5,7 +5,7 @@
             Articles
             <div class="text-right"><i class="fas fa-book"></i></div>
         </div>
-        <a href="articles" class="small-box-footer">View articles <i class="fas fa-arrow-circle-right"></i></a>
+        <a href="{{route('admin:articles.index')}}" class="small-box-footer">View articles <i class="fas fa-arrow-circle-right"></i></a>
     </div>
 </div>
     <div class="col-6 col-sm">

--- a/src/routes/admin.php
+++ b/src/routes/admin.php
@@ -3,8 +3,10 @@
 use App\Http\Controllers\Admin\StaticAdminController;
 use App\Http\Controllers\admin\VolumeAdminController;
 use App\Http\Controllers\UserAdminController;
+use App\Http\Controllers\Admin\ArticleAdminController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [StaticAdminController::class, 'dashboard'])->name('dashboard');
 Route::resource('users', UserAdminController::class);
 Route::resource('/volumes', VolumeAdminController::class);
+Route::resource('/articles', ArticleAdminController::class);


### PR DESCRIPTION
Now the button redirects the user to `/admin/articles` instead of `/articles`.